### PR TITLE
Fix package name

### DIFF
--- a/lightkeeper/src/main/java/lightkeeper/LightKeeperPlugin.java
+++ b/lightkeeper/src/main/java/lightkeeper/LightKeeperPlugin.java
@@ -15,6 +15,7 @@
  */
 package lightkeeper;
 
+import ghidra.app.CorePluginPackage;
 import ghidra.app.plugin.PluginCategoryNames;
 import ghidra.app.plugin.ProgramPlugin;
 import ghidra.framework.plugintool.PluginInfo;
@@ -32,7 +33,7 @@ import lightkeeper.model.table.CoverageTableModel;
 import lightkeeper.view.LightKeeperProvider;
 
 //@formatter:off
-@PluginInfo(status = PluginStatus.STABLE, packageName = "light keeper", category = PluginCategoryNames.MISC, shortDescription = "Plugin for visualization of DynamoRio coverage data.", description = "Plugin for visualization of DynamoRio coverage data.")
+@PluginInfo(status = PluginStatus.STABLE, packageName = CorePluginPackage.NAME, category = PluginCategoryNames.MISC, shortDescription = "Plugin for visualization of DynamoRio coverage data.", description = "Plugin for visualization of DynamoRio coverage data.")
 //@formatter:on
 public class LightKeeperPlugin extends ProgramPlugin {
 	protected CoverageModel coverageModel;


### PR DESCRIPTION
This removes the following error message:

```
│2024-06-09 16:10:48 WARN  (PluginPackage) Can't find plugin package for light keeper! Creating stub...
```
and groups it with other plugins such as [ret-sync](https://github.com/bootleg/ret-sync/blob/a6d0b53826d0dc5a075229ce5efe9004f834339e/ext_ghidra/src/main/java/retsync/RetSyncPlugin.java#L67-L83) 

This is required as the created stub doesn't show up in the CodeBrowsers `File > Configure` meaning it can't be enabled when not installed through the UI.