### PR TITLE
Allow users to specify colors

### DIFF
--- a/lightkeeper/data/lightkeeper.theme.properties
+++ b/lightkeeper/data/lightkeeper.theme.properties
@@ -1,0 +1,13 @@
+[Defaults]
+color.lightkeeper.coverage_lt_20.bg=color.palette.blue
+color.lightkeeper.coverage_lt_20.fg=color.palette.white
+color.lightkeeper.coverage_lt_40.bg=color.palette.green
+color.lightkeeper.coverage_lt_40.fg=color.palette.black
+color.lightkeeper.coverage_lt_60.bg=color.palette.yellow
+color.lightkeeper.coverage_lt_60.fg=color.palette.black
+color.lightkeeper.coverage_lt_80.bg=color.palette.orange
+color.lightkeeper.coverage_lt_80.fg=color.palette.black
+color.lightkeeper.coverage_default.bg=color.palette.red
+color.lightkeeper.coverage_default.fg=color.palette.white
+color.lightkeeper.disassembly_highlight=color.palette.green
+color.lightkeeper.instruction_highlight=color.palette.green

--- a/lightkeeper/src/main/java/lightkeeper/controller/Controller.java
+++ b/lightkeeper/src/main/java/lightkeeper/controller/Controller.java
@@ -5,6 +5,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 
+import generic.theme.GColor;
 import ghidra.app.plugin.core.colorizer.ColorizingService;
 import ghidra.app.services.CodeViewerService;
 import ghidra.app.services.ConsoleService;
@@ -28,6 +29,7 @@ public class Controller implements IEventListener, ICoverageModelListener {
 	protected CoverageModel model;
 	protected CoverageTableModel tableModel;
 	protected CoverageInstructionModel instructionModel;
+	protected GColor color;
 
 	public Controller(LightKeeperPlugin plugin, CoverageModel model, CoverageTableModel tableModel,
 			CoverageInstructionModel instructionModel) {
@@ -35,6 +37,7 @@ public class Controller implements IEventListener, ICoverageModelListener {
 		this.model = model;
 		this.tableModel = tableModel;
 		this.instructionModel = instructionModel;
+		this.color = new GColor("color.lightkeeper.instruction_highlight");
 	}
 
 	public void goTo(CoverageTableRow row) {
@@ -75,7 +78,7 @@ public class Controller implements IEventListener, ICoverageModelListener {
 				monitor.checkCancelled();
 				var min = range.getMinAddress();
 				var max = range.getMaxAddress();
-				colorService.setBackgroundColor(min, max, Color.GREEN);
+				colorService.setBackgroundColor(min, max, this.color);
 			}
 			completed = true;
 		} finally {

--- a/lightkeeper/src/main/java/lightkeeper/controller/DisassemblyController.java
+++ b/lightkeeper/src/main/java/lightkeeper/controller/DisassemblyController.java
@@ -6,6 +6,7 @@ import java.math.BigInteger;
 import docking.widgets.fieldpanel.LayoutModel;
 import docking.widgets.fieldpanel.listener.IndexMapper;
 import docking.widgets.fieldpanel.listener.LayoutModelListener;
+import generic.theme.GColor;
 import ghidra.app.decompiler.ClangLine;
 import ghidra.app.decompiler.ClangToken;
 import ghidra.app.decompiler.component.DecompilerPanel;
@@ -24,10 +25,12 @@ import lightkeeper.model.instruction.CoverageInstructionModel;
 public class DisassemblyController implements ICoverageModelListener {
 	protected LightKeeperPlugin plugin;
 	protected CoverageInstructionModel model;
+	protected GColor color;
 
 	public DisassemblyController(LightKeeperPlugin plugin, CoverageInstructionModel model) {
 		this.plugin = plugin;
 		this.model = model;
+		this.color = new GColor("color.lightkeeper.disassembly_highlight");
 	}
 
 	@Override
@@ -77,7 +80,7 @@ public class DisassemblyController implements ICoverageModelListener {
 						continue;
 					}
 
-					token.setHighlight(Color.GREEN);
+					token.setHighlight(this.color);
 				}
 			}
 		}

--- a/lightkeeper/src/main/java/lightkeeper/view/LightKeeperProvider.java
+++ b/lightkeeper/src/main/java/lightkeeper/view/LightKeeperProvider.java
@@ -39,6 +39,7 @@ import docking.widgets.table.GTableCellRenderingData;
 import docking.widgets.table.TableSortState;
 import docking.widgets.table.TableSortStateEditor;
 import docking.widgets.table.ColumnSortState.SortDirection;
+import generic.theme.GColor;
 import ghidra.util.Msg;
 import ghidra.util.exception.CancelledException;
 import ghidra.util.task.Task;
@@ -125,6 +126,19 @@ public class LightKeeperProvider extends ComponentProvider implements TableModel
 				return component;
 			}
 		});
+
+		final var colors = new GColor[] {
+			new GColor("color.lightkeeper.coverage_lt_20.bg"),
+			new GColor("color.lightkeeper.coverage_lt_20.fg"),
+			new GColor("color.lightkeeper.coverage_lt_40.bg"),
+			new GColor("color.lightkeeper.coverage_lt_40.fg"),
+			new GColor("color.lightkeeper.coverage_lt_60.bg"),
+			new GColor("color.lightkeeper.coverage_lt_60.fg"),
+			new GColor("color.lightkeeper.coverage_lt_80.bg"),
+			new GColor("color.lightkeeper.coverage_lt_80.fg"),
+			new GColor("color.lightkeeper.coverage_default.bg"),
+			new GColor("color.lightkeeper.coverage_default.fg")
+		};
 		tableView.getColumnModel().getColumn(0).setCellRenderer(new GTableCellRenderer() {
 			@Override
 			public Component getTableCellRendererComponent(GTableCellRenderingData data) {
@@ -149,20 +163,20 @@ public class LightKeeperProvider extends ComponentProvider implements TableModel
 
 			private void setPercentageBackgroundColor(Component component, double coverage) {
 				if (coverage < 0.20d) {
-					component.setBackground(Color.BLUE);
-					component.setForeground(Color.WHITE);
+					component.setBackground(colors[0]);
+					component.setForeground(colors[1]);
 				} else if (coverage < 0.40d) {
-					component.setBackground(Color.GREEN);
-					component.setForeground(Color.BLACK);
+					component.setBackground(colors[2]);
+					component.setForeground(colors[3]);
 				} else if (coverage < 0.60d) {
-					component.setBackground(Color.YELLOW);
-					component.setForeground(Color.BLACK);
+					component.setBackground(colors[4]);
+					component.setForeground(colors[5]);
 				} else if (coverage < 0.80d) {
-					component.setBackground(Color.ORANGE);
-					component.setForeground(Color.BLACK);
+					component.setBackground(colors[6]);
+					component.setForeground(colors[7]);
 				} else {
-					component.setBackground(Color.RED);
-					component.setForeground(Color.WHITE);
+					component.setBackground(colors[8]);
+					component.setForeground(colors[9]);
 				}
 			}
 		});


### PR DESCRIPTION
Using the GColor Class and by defining the names used in a properties file, users are able to change the colors used by Lightkeeper.
This is especially useful, now that Ghidra supports a dark mode with bright text, that made the highlighted disassembly completely unreadable.