### PR TITLE
Support for Ghidra 12.0.4 and DRCOV v3/v5

### DIFF
--- a/.github/workflows/build_on_tag_push.yml
+++ b/.github/workflows/build_on_tag_push.yml
@@ -1,9 +1,9 @@
 name: Ghidra Extension Publish
 
 env:
-  ghidra-url: https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_11.3.1_build/ghidra_11.3.1_PUBLIC_20250219.zip
-  ghidra-zip-filename: ghidra_11.3.1_PUBLIC_20250219.zip
-  ghidra-directory: ghidra_11.3.1_PUBLIC
+  ghidra-url: https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_12.0.4_build/ghidra_12.0.4_PUBLIC_20260303.zip
+  ghidra-zip-filename: ghidra_12.0.4_PUBLIC_20260303.zip
+  ghidra-directory: ghidra_12.0.4_PUBLIC
 
 on:
   push:

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,7 +4,7 @@
         {
           "label": "Build",
           "type": "shell",
-          "command": "gradle -PGHIDRA_INSTALL_DIR=/opt/ghidra_11.3.1_PUBLIC",
+          "command": "gradle -PGHIDRA_INSTALL_DIR=/opt/ghidra_12.0.4_PUBLIC",
           "group": "build",
           "options": {
               "cwd": "${workspaceFolder}/lightkeeper"

--- a/lightkeeper/build.gradle
+++ b/lightkeeper/build.gradle
@@ -32,11 +32,11 @@
 //----------------------START "DO NOT MODIFY" SECTION------------------------------
 def ghidraInstallDir
 
-if (System.env.GHIDRA_INSTALL_DIR) {
-	ghidraInstallDir = System.env.GHIDRA_INSTALL_DIR
-}
-else if (project.hasProperty("GHIDRA_INSTALL_DIR")) {
+if (project.hasProperty("GHIDRA_INSTALL_DIR")) {
 	ghidraInstallDir = project.getProperty("GHIDRA_INSTALL_DIR")
+}
+else if (System.env.GHIDRA_INSTALL_DIR) {
+	ghidraInstallDir = System.env.GHIDRA_INSTALL_DIR
 }
 
 if (ghidraInstallDir) {

--- a/lightkeeper/src/main/java/lightkeeper/io/file/DynamoRioFile.java
+++ b/lightkeeper/src/main/java/lightkeeper/io/file/DynamoRioFile.java
@@ -20,7 +20,7 @@ import lightkeeper.io.module.ModuleEntry;
 import lightkeeper.io.module.ModuleReader;
 
 public class DynamoRioFile implements IEventListener {
-	protected final String HEADER = "DRCOV VERSION: 2";
+	protected final Pattern HEADER_REGEX = Pattern.compile("^DRCOV VERSION: (?<version>[23])$");
 	protected final Pattern FLAVOUR_REGEX = Pattern.compile("^DRCOV FLAVOR: (?<flavour>.*)$");
 	protected final Pattern TABLE_REGEX = Pattern
 			.compile("^Module Table: (version (?<version>\\d+), count )?(?<count>\\d+)$");
@@ -31,6 +31,7 @@ public class DynamoRioFile implements IEventListener {
 	protected File file;
 
 	protected String flavour;
+	protected int fileVersion;
 	protected int tableVersion;
 	protected int tableCount;
 	protected ArrayList<ModuleEntry> modules = new ArrayList<>();
@@ -78,9 +79,12 @@ public class DynamoRioFile implements IEventListener {
 		monitor.setMessage("Reading header");
 		var headerLine = reader.readLine();
 		addMessage(headerLine);
-		if (!headerLine.equals(HEADER)) {
-			throw new IOException(String.format("Invalid header: '%s' expected '%s'", headerLine, HEADER));
+		var headerMatcher = HEADER_REGEX.matcher(headerLine);
+		if (!headerMatcher.matches()) {
+			throw new IOException(String.format("Invalid header: '%s'", headerLine));
 		}
+		fileVersion = Integer.parseInt(headerMatcher.group("version"));
+		addMessage(String.format("Detected file version: %d", fileVersion));
 		monitor.checkCancelled();
 	}
 

--- a/lightkeeper/src/main/java/lightkeeper/io/module/ModuleReader.java
+++ b/lightkeeper/src/main/java/lightkeeper/io/module/ModuleReader.java
@@ -22,17 +22,28 @@ public class ModuleReader {
 			"^\\s*(?<id>\\d+), (0x)?(?<start>[0-9a-fA-F]+), (0x)?(?<end>[0-9a-fA-F]+), (0x)?(?<entry>[0-9a-fA-F]+), (?<path>.+)$");
 
 	protected final String COLUMN_3_HDR_WIN = "Columns: id, containing_id, start, end, entry, checksum, timestamp, path";
-	protected final Pattern COLUMN_3_HDR_WIN_FMT = null;
+	protected final Pattern COLUMN_3_HDR_WIN_FMT = Pattern.compile(
+			"^\\s*(?<id>\\d+), \\s*(?<containingid>\\d+), (0x)?(?<start>[0-9a-fA-F]+), (0x)?(?<end>[0-9a-fA-F]+), (0x)?(?<entry>[0-9a-fA-F]+), (0x)?(?<checksum>[0-9a-fA-F]+), (0x)?(?<timestamp>[0-9a-fA-F]+), (?<path>.+)$");
 
 	protected final String COLUMN_3_HDR_LINUX = "Columns: id, containing_id, start, end, entry, path";
-	protected final Pattern COLUMN_3_HDR_LINUX_FMT = null;
+	protected final Pattern COLUMN_3_HDR_LINUX_FMT = Pattern.compile(
+			"^\\s*(?<id>\\d+), \\s*(?<containingid>\\d+), (0x)?(?<start>[0-9a-fA-F]+), (0x)?(?<end>[0-9a-fA-F]+), (0x)?(?<entry>[0-9a-fA-F]+), (?<path>.+)$");
 
 	protected final String COLUMN_4_HDR_WIN = "Columns: id, containing_id, start, end, entry, offset, checksum, timestamp, path";
-	protected final Pattern COLUMN_4_HDR_WIN_FMT = null;
+	protected final Pattern COLUMN_4_HDR_WIN_FMT = Pattern.compile(
+			"^\\s*(?<id>\\d+), \\s*(?<containingid>\\d+), (0x)?(?<start>[0-9a-fA-F]+), (0x)?(?<end>[0-9a-fA-F]+), (0x)?(?<entry>[0-9a-fA-F]+), (0x)?(?<offset>[0-9a-fA-F]+), (0x)?(?<checksum>[0-9a-fA-F]+), (0x)?(?<timestamp>[0-9a-fA-F]+), (?<path>.+)$");
 
 	protected final String COLUMN_4_HDR_LINUX = "Columns: id, containing_id, start, end, entry, offset, path";
 	protected final Pattern COLUMN_4_HDR_LINUX_FMT = Pattern.compile(
 			"^\\s*(?<id>\\d+), \\s*(?<containingid>\\d+), (0x)?(?<start>[0-9a-fA-F]+), (0x)?(?<end>[0-9a-fA-F]+), (0x)?(?<entry>[0-9a-fA-F]+), (0x)?(?<offset>[0-9a-fA-F]+), (?<path>.+)$");
+
+	protected final String COLUMN_5_HDR_WIN = "Columns: id, containing_id, start, end, entry, offset, preferred_base, checksum, timestamp, path";
+	protected final Pattern COLUMN_5_HDR_WIN_FMT = Pattern.compile(
+			"^\\s*(?<id>\\d+), \\s*(?<containingid>\\d+), (0x)?(?<start>[0-9a-fA-F]+), (0x)?(?<end>[0-9a-fA-F]+), (0x)?(?<entry>[0-9a-fA-F]+), (0x)?(?<offset>[0-9a-fA-F]+), (0x)?(?<preferredbase>[0-9a-fA-F]+), (0x)?(?<checksum>[0-9a-fA-F]+), (0x)?(?<timestamp>[0-9a-fA-F]+), (?<path>.+)$");
+
+	protected final String COLUMN_5_HDR_LINUX = "Columns: id, containing_id, start, end, entry, offset, preferred_base, path";
+	protected final Pattern COLUMN_5_HDR_LINUX_FMT = Pattern.compile(
+			"^\\s*(?<id>\\d+), \\s*(?<containingid>\\d+), (0x)?(?<start>[0-9a-fA-F]+), (0x)?(?<end>[0-9a-fA-F]+), (0x)?(?<entry>[0-9a-fA-F]+), (0x)?(?<offset>[0-9a-fA-F]+), (0x)?(?<preferredbase>[0-9a-fA-F]+), (?<path>.+)$");
 
 	protected final Pattern NULL_CHECKSUM = Pattern.compile("0+");
 
@@ -71,6 +82,8 @@ public class ModuleReader {
 		formats.add(new ModuleTriplet(3, COLUMN_3_HDR_LINUX, COLUMN_3_HDR_LINUX_FMT, true, false));
 		formats.add(new ModuleTriplet(4, COLUMN_4_HDR_WIN, COLUMN_4_HDR_WIN_FMT, true, true));
 		formats.add(new ModuleTriplet(4, COLUMN_4_HDR_LINUX, COLUMN_4_HDR_LINUX_FMT, true, false));
+		formats.add(new ModuleTriplet(5, COLUMN_5_HDR_WIN, COLUMN_5_HDR_WIN_FMT, true, true));
+		formats.add(new ModuleTriplet(5, COLUMN_5_HDR_LINUX, COLUMN_5_HDR_LINUX_FMT, true, false));
 
 		readColumnHeader();
 

--- a/lightkeeper/src/main/java/lightkeeper/model/coverage/CoverageModel.java
+++ b/lightkeeper/src/main/java/lightkeeper/model/coverage/CoverageModel.java
@@ -56,7 +56,7 @@ public class CoverageModel extends AbstractCoverageModel<DynamoRioFile, AddressS
 		var api = plugin.getApi();
 		var programFileName = api.getCurrentProgram().getName();
 		var selectedModules = file.getModules().stream()
-				.filter(m -> new File(m.getPath()).getName().trim().equals(programFileName))
+				.filter(m -> new File(m.getPath()).getName().trim().equalsIgnoreCase(programFileName))
 				.collect(Collectors.toList());
 		if (selectedModules.isEmpty()) {
 			addMessage(String.format("Found %d modules", file.getModules().size()));
@@ -112,11 +112,12 @@ public class CoverageModel extends AbstractCoverageModel<DynamoRioFile, AddressS
 				var selectedModules = getSelectedModules(file);
 
 				var misMatch = selectedModules.stream().filter(m -> m.getChecksum() != null)
+						.filter(m -> m.getChecksum().length() == md5.length())
 						.filter(m -> !m.getChecksum().equalsIgnoreCase(md5)).findFirst();
 				if (misMatch.isPresent()) {
 					var module = misMatch.get();
-					throw new IOException(String.format("Module entry '%s' has invalid checksum '%s'", module.getPath(),
-							module.getChecksum()));
+					addErrorMessage(String.format("Warning: module '%s' has checksum '%s' but loaded binary has MD5 '%s' - coverage may be inaccurate",
+							module.getPath(), module.getChecksum(), md5));
 				}
 
 				Set<Integer> ids = this.getSelectedModuleIds(selectedModules);

--- a/lightkeeper/src/main/java/lightkeeper/model/list/CoverageList.java
+++ b/lightkeeper/src/main/java/lightkeeper/model/list/CoverageList.java
@@ -5,6 +5,7 @@ import java.util.List;
 import docking.widgets.table.AbstractSortedTableModel;
 import docking.widgets.table.ColumnSortState.SortDirection;
 import docking.widgets.table.TableSortStateEditor;
+import ghidra.util.Swing;
 import ghidra.util.exception.CancelledException;
 import ghidra.util.task.TaskMonitor;
 import lightkeeper.model.ICoverageModelListener;
@@ -68,6 +69,6 @@ public class CoverageList extends AbstractSortedTableModel<CoverageListRow> impl
 
 	@Override
 	public void modelChanged(TaskMonitor monitor) throws CancelledException {
-		fireTableDataChanged();
+		Swing.runLater(() -> fireTableDataChanged());
 	}
 }

--- a/lightkeeper/src/main/java/lightkeeper/model/table/CoverageTable.java
+++ b/lightkeeper/src/main/java/lightkeeper/model/table/CoverageTable.java
@@ -5,6 +5,7 @@ import java.util.List;
 import docking.widgets.table.AbstractSortedTableModel;
 import docking.widgets.table.ColumnSortState.SortDirection;
 import docking.widgets.table.TableSortStateEditor;
+import ghidra.util.Swing;
 import ghidra.util.exception.CancelledException;
 import ghidra.util.task.TaskMonitor;
 import lightkeeper.model.ICoverageModelListener;
@@ -70,6 +71,6 @@ public class CoverageTable extends AbstractSortedTableModel<CoverageTableRow> im
 
 	@Override
 	public void modelChanged(TaskMonitor monitor) throws CancelledException {
-		fireTableDataChanged();
+		Swing.runLater(() -> fireTableDataChanged());
 	}
 }


### PR DESCRIPTION
This updates the repository to support the newest DynamoRIO coverage files from version [11.90.20395](https://github.com/DynamoRIO/dynamorio/releases/tag/cronbuild-11.90.20395). In addition it was updated to work with Ghidra 12.0.4. This version will also prioritise the -PGHIDRA_INSTALL_DIR flag over GHIDRA_INSTALL_DIR env var if provided with gradle during build. This allows for compiling on the CLI with gradle against targeted Ghidra folder.

- Accept DRCOV VERSION 2 and 3 file headers
- Add module table version 5 support (adds preferred_base column)
- Add missing regex parsers for module table versions 3 and 4 (Windows)
- Fix case-insensitive module name matching for Windows DLLs
- Demote checksum mismatch from hard error to warning (PE checksums are not comparable to MD5 hashes used by Ghidra)
- Fix table/list UI not updating by wrapping fireTableDataChanged() in Swing.runLater() for Ghidra 12 EDT compliance
- Prioritise -PGHIDRA_INSTALL_DIR flag over GHIDRA_INSTALL_DIR env var
- Update CI and VS Code build config to Ghidra 12.0.4